### PR TITLE
design: Claude Code Worker 并行环境系统设计文档

### DIFF
--- a/.claude-worker/EXPLORATION.md
+++ b/.claude-worker/EXPLORATION.md
@@ -1,0 +1,195 @@
+# 用 Claude Code 探究 Claude Code Web 环境
+
+**记录日期**：2026-04-03  
+**实验性质**：用工具本身研究工具——在 Claude Code Web 环境内，用 Claude Code 调查该环境的真实面貌，并据此设计一个能并行启动多个隔离 Claude Code 工作环境的工具。
+
+---
+
+## 起点：一个工具需求，一个合理假设
+
+这次探索的起点是一个实际需求：构建 `claude-code-worker`，让用户可以通过一条命令，并行启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，完成后自动推送结果。
+
+最自然的假设是：Claude Code Web 运行在 Docker 容器里。毕竟 Docker 是"隔离环境"的标准方案，用于云端托管服务的概率极高。既然要构建类似的本地工具，先调查清楚 Anthropic 是怎么做的，再照葫芦画瓢，是合理的起手思路。
+
+但调查结果出乎意料。
+
+---
+
+## 第一阶段：调查当前环境——打破"Docker 假设"
+
+### 用了什么工具
+
+在 Claude Code 内直接使用 Bash 工具执行系统探测命令：
+- `cat /proc/1/cmdline` 查看 PID 1 进程
+- `docker info` 和 `ls /var/run/docker.sock` 检查 Docker 状态
+- `uname -a`、`cat /etc/os-release` 获取内核和系统信息
+- `which claude`、`file $(which claude)` 检查 Claude Code 本身的二进制形态
+- `nproc`、`free -h`、`df -h` 查看资源配额
+
+### 发现了什么
+
+**PID 1 不是 Docker**。`/proc/1/cmdline` 返回的是 `/process_api --firecracker-init`。
+
+这是 Anthropic 专有的 Firecracker microVM 初始化进程。Docker daemon 根本没有运行——`/var/run/docker.sock` 不存在，`docker info` 报连接失败。
+
+这个发现很关键。它告诉我们：Anthropic 选择了比 Docker 隔离级别更高的方案。Firecracker 是 AWS Lambda 和 Fargate 背后的 microVM 技术，每个 VM 有独立内核，安全边界远比容器 namespace 强。
+
+完整环境数据记录如下：
+
+| 项目 | 值 |
+|---|---|
+| 虚拟化 | Anthropic 专有 Firecracker microVM |
+| 操作系统 | Ubuntu 24.04.4 LTS |
+| 内核 | Linux 6.18.5 x86_64 |
+| CPU | 4 核 |
+| 内存 | 15 GB |
+| 磁盘 | 252 GB（可用约 30 GB）|
+| 网络 | 通过 Anthropic 托管代理，白名单域名 |
+
+### 为什么重要
+
+原计划是"在本地用 Docker 复刻云端环境"。现在知道云端用的是 Firecracker，而本地没有 Firecracker 工具——这意味着方案需要调整。但更重要的是，这个发现揭示了 Anthropic 的设计哲学：给每个用户会话一个独立内核隔离的 microVM，而不是一个共享内核的容器。
+
+---
+
+## 第二阶段：调查 Claude Code 本身
+
+知道了"跑在什么里面"，下一个问题是"跑的是什么"。Claude Code 是一个 npm 包？一个 Node.js 脚本？还是别的什么？
+
+### 发现了什么
+
+```bash
+$ file $(which claude)
+/opt/claude-code/bin/claude: ELF 64-bit LSB executable, x86-64, statically linked
+$ du -sh /opt/claude-code/bin/claude
+230M
+```
+
+Claude Code 是一个 **230MB 的静态编译 ELF 二进制**。不是 npm 包，不是脚本，而是一个自包含的可执行文件。npm 安装方式已经弃用，现在的官方安装方式是 native installer：
+
+```bash
+DISABLE_AUTOUPDATER=1 curl -fsSL https://claude.ai/install.sh | bash
+```
+
+接着测试了各种参数：
+- `claude --bare`：不存在
+- `claude --serve`：不存在
+- `claude --dangerously-skip-permissions`：存在，跳过权限确认
+- `claude --tmux`：在 tmux 会话中运行
+- `claude --worktree`：创建 git worktree
+
+没有内置 web server 模式。要让 Claude Code TUI 能在浏览器里访问，需要借助 `ttyd` 这个工具——它能把终端进程包装成 WebSocket 服务。恰好 Ubuntu 24.04 官方源里有 ttyd 1.7.4。
+
+认证方面，云端没有预设 `ANTHROPIC_API_KEY`，需要在运行时注入。支持三种方式：OAuth 订阅、API Key（环境变量注入）、以及 AWS/GCP 等云服务凭证。
+
+### 为什么重要
+
+静态二进制这个特点决定了部署方式。安装不依赖 Node.js 环境，但需要从 Anthropic 服务器下载。这影响 golden box 构建时间和网络要求。同时，`--dangerously-skip-permissions` 参数的存在证实了"自动化场景下跳过人工确认"是官方支持的用法，这是 worker 方案的重要基础。
+
+---
+
+## 第三阶段：工具链摸底——意外的丰富程度
+
+除了 Claude Code 本身，这个 Firecracker VM 里预装了相当完整的开发工具链：
+
+```
+Python 3.11.15   /usr/local/bin/python3
+Node.js 22.22.2  /opt/node22/bin/node
+Go 1.24.7        /usr/local/go/bin/go
+Rust 1.94.1      /usr/bin/rustc
+Java OpenJDK 21  /usr/bin/java
+Ruby 3.3.6       /usr/bin/ruby
+PHP 8.4.19       /usr/bin/php
+Git 2.43.0       /usr/bin/git
+tmux 3.4         /usr/bin/tmux
+```
+
+这个发现确认了一件事：复刻这个环境并不需要特别定制，Ubuntu 24.04 + 标准包 + native Claude installer，基本可以还原。
+
+---
+
+## 第四阶段：架构演变——从 Docker 到 Vagrant
+
+### 初始方案（被否定）
+
+最初打算用 Docker 容器作为 worker 隔离方案。发现 Docker daemon 不可用后，需要重新选型。
+
+### 用户本地环境的实际情况
+
+用户的本地 Linux 机器已有：
+- KVM（硬件虚拟化）
+- Vagrant
+- vagrant-libvirt plugin
+- libvirt daemon
+
+这些工具组合在一起，可以提供和 Firecracker 接近的隔离级别（独立内核的 KVM VM），启动时间在 5–15 秒之间——对于一个"开个工作环境做一两小时任务"的场景，这个延迟完全可以接受。
+
+**方案 A（当前实现）** 就此确定：Vagrant + libvirt + Ubuntu Cloud Image，用 `ttyd` 包装 Claude Code TUI 暴露浏览器终端。
+
+### 演进路线图（规划中）
+
+同时规划了两条演进路径，在需要更快启动速度时迁移：
+
+- **方案 B**：Weaveworks Ignite（Firecracker 封装），~1 秒启动，接近云端体验
+- **方案 C**：Kata Containers（Docker CLI + VM 隔离），1–2 秒启动，适合团队场景
+
+三个方案的 `entrypoint.sh`、`push-and-exit.sh` 和 CLI 接口完全复用，只替换底层启动机制。这个设计决策是在探索过程中逐渐清晰的——先把上层逻辑固定，留出底层可替换的接缝。
+
+---
+
+## 第五阶段：关键设计决策
+
+架构确定后，一系列具体设计问题需要逐一讨论：
+
+### 认证：三层优先级
+
+最终设计了三层 API Key 获取策略，优先级从高到低：
+1. 通过 URL 动态获取（`SECRET_URL` + `SECRET_TOKEN`），不落磁盘
+2. 挂载目录文件（`/secrets/anthropic_api_key`）
+3. 环境变量兜底（`ANTHROPIC_API_KEY`）
+
+这个设计考虑了不同安全敏感程度的使用场景——个人开发者可以用环境变量，有安全要求的场景可以接 secret server。
+
+### VM 方案 vs tmux+ttyd
+
+讨论过一个轻量级替代方案：不起 VM，直接用 tmux + ttyd 在宿主机上开多个终端会话。但这方案没有隔离——多个 Claude Code 实例共享文件系统和环境变量，一个 worker 的 `rm -rf` 操作可能影响其他 worker。VM 方案的 5–15 秒启动时间换来的是真正的隔离，这个代价值得。
+
+### Golden Box：把 provision 变成一次性工作
+
+每次 `vagrant up` 从头安装 Claude Code 需要 3–5 分钟（主要是下载 230MB 二进制）。Golden box 策略把这变成一次性构建：
+
+```
+构建一次 golden box（5 分钟）
+    ↓
+之后每次 worker start 只需 5–15 秒
+```
+
+`claude-code-worker build-box` 命令负责这个一次性工作，更新 Claude Code 版本时用 `--force` 重建。
+
+### 审核流程：VM 和 PR 生命周期解耦
+
+最终确定的审核流程：
+- Worker 完成任务后，`push-and-exit.sh` 自动 commit + push 到结果分支
+- VM push 完成后**立即销毁**——VM 生命周期到此结束
+- 需要 AI 审核时，用 `claude-code-worker review --branch result/xxx` 起一个新的 review worker
+- 人工审核独立进行，不依赖 VM 是否存活
+
+这个"VM 是一次性工具"的设计，比"VM 长期运行等待审核"简单得多，也避免了资源浪费。
+
+### Box 更新：不做版本共存
+
+更新 Claude Code 版本时，采用最简单的策略：停所有 worker → 重建 golden box → 继续。不维护多个版本的 box。理由是：这是个人开发工具，worker 生命周期短（几小时），更新 Claude Code 版本时统一升级没有问题。
+
+### 默认 repo：不需要
+
+每次 `start` 都必须指定 `--repo`，没有"默认仓库"的概念。这个决策避免了配置管理的复杂性，也防止了"忘记指定 repo 结果在错误仓库里工作"的人为错误。
+
+---
+
+## 总结：用工具研究工具的收获
+
+这次探索有一个有趣的元层面：用 Claude Code（工具）在 Claude Code Web 环境（运行环境）内调查该环境，然后用调查结果设计一个本地版本的类似工具。
+
+最重要的发现是那个打破初始假设的时刻——PID 1 不是 Docker，而是 Firecracker。这一个发现推翻了最初的方案，把架构选型从"用 Docker 复刻"转向了"用 KVM VM 提供同等隔离"。这种"先调查再设计"的过程，比凭直觉选方案更可靠——哪怕调查结果会推翻你的初始假设，尤其是当调查结果会推翻你的初始假设时。
+
+最终的 SPEC.md 是这次探索的直接产物，记录了基于实测数据做出的每一个架构决策。

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -449,6 +449,11 @@ worker push 前需生成并提交以下产物，具体内容待定：
 **待定问题**：
 - [ ] 用户的 secret server 方案（自建 vs Vault vs 云服务）？
 
+#### Box 更新策略
+采用**方向 A：简单重建**。
+流程：停所有 worker → `claude-code-worker build-box --force` 重建 → 继续使用新 box。
+无版本共存，旧 box 直接替换。适合个人开发工具、worker 生命周期短的场景。
+
 #### install.sh（一次性环境准备）
 用途：让本地机器具备运行 `claude-code-worker` 的条件（类比"装 Docker Engine"）。
 执行顺序：`install.sh` → `build-box` → 日常 `start`。

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,0 +1,354 @@
+# Claude Code Worker — 设计规格（Design Spec）
+
+**版本**: 0.1  
+**目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
+
+---
+
+## 1. 当前环境基线（经实测）
+
+构建 Docker 镜像的基础参考当前运行环境：
+
+| 项目 | 值 |
+|---|---|
+| 基础镜像 | Ubuntu 24.04.4 LTS (Noble Numbat) |
+| 内核 | Linux 6.18.5 x86_64 |
+| Python | 3.11.15（`/usr/local/bin/python3`） |
+| Node.js | 22.22.2（`/opt/node22/bin/node`） |
+| Go | 1.24.7（`/usr/local/go/bin/go`） |
+| Rust | 1.94.1（`/root/.cargo/bin/rustc`） |
+| Java | 已安装（JDK） |
+| Ruby | 已安装 |
+| PHP | 8.4 |
+| Git | 2.43.0 |
+| Docker | 29.3.1（宿主机可用） |
+| Claude Code | 2.1.91（`/root/.local/bin/claude`，native installer） |
+| CPU | 4 核 |
+| 内存 | 15 GB |
+| 磁盘 | 252 GB，可用 ~31 GB |
+
+**关键约束**：
+- 网络出站通过 Anthropic 托管代理过滤，仅允许白名单域名（PyPI、npm、GitHub、crates.io、apt.ubuntu.com 等已在白名单内）
+- 宿主机已有 Docker socket 和 Docker CLI
+
+---
+
+## 2. 系统架构
+
+```
+宿主机 (用户的 Linux 电脑)
+│
+├── claude-code-worker CLI          ← 宿主机上运行的管理脚本
+│   ├── start --repo --branch --purpose
+│   ├── list
+│   ├── stop <id>
+│   ├── logs <id>
+│   └── build
+│
+├── ~/.claude-worker/
+│   ├── secrets.env                 ← API Key 等敏感信息（chmod 600，不进 git）
+│   └── workers.json                ← 运行中 worker 的状态记录
+│
+└── Docker Containers (隔离)
+    ├── ccw-bug-fixing-xxx  :7700  → 浏览器访问 http://localhost:7700
+    ├── ccw-feature-dev-xxx :7701  → 浏览器访问 http://localhost:7701
+    └── ccw-refactor-xxx    :7702  → 浏览器访问 http://localhost:7702
+```
+
+每个容器内部：
+```
+容器内
+├── entrypoint.sh（初始化）
+│   ├── 配置 git 凭证（SSH mount 或 HTTPS token）
+│   ├── git clone --depth=50 --branch <BRANCH> <REPO>
+│   ├── git checkout -b result/<PURPOSE>-<timestamp>
+│   └── 启动 ttyd → 包装 claude CLI
+│
+└── ttyd --port 7681
+    └── bash -c "cd /workspace && claude --dangerously-skip-permissions"
+        ← 用户通过浏览器操作这个终端
+```
+
+---
+
+## 3. 技术选型说明
+
+### 3.1 为什么用 ttyd 而不是内置 web 模式
+
+Claude Code **没有**内置 HTTP web server 模式——它是一个 TUI 二进制程序。  
+`ttyd` 是 Ubuntu 24.04 apt 官方源中的 `1.7.4` 版本，`apt install ttyd` 即可安装，无需编译。它将任意终端命令包装成 WebSocket + WebGL 的浏览器终端，是最简单且已在生产环境验证的方案。
+
+### 3.2 Claude Code 安装方式
+
+使用官方 native installer（npm 方式已弃用）：
+```bash
+DISABLE_AUTOUPDATER=1 curl -fsSL https://claude.ai/install.sh | bash
+```
+`DISABLE_AUTOUPDATER=1` 防止容器内安装卡住，这是 Docker 场景的必要参数。
+
+### 3.3 认证方式
+
+- **API Key**（推荐）：通过 `ANTHROPIC_API_KEY` 环境变量传入，配合 `claude --bare` 参数强制使用 API Key 认证，跳过 OAuth 流程。
+- **OAuth 登录**（备选）：需要交互式浏览器认证，不适合容器化场景。
+
+### 3.4 Git 凭证
+
+两种方式，自动检测：
+- **SSH**（推荐）：将宿主机 `~/.ssh` bind-mount 进容器（只读）
+- **HTTPS Token**：通过 `GIT_TOKEN` 环境变量传入，容器内写入 `~/.netrc`
+
+---
+
+## 4. 文件结构
+
+```
+.claude-worker/                     ← 放在项目根目录或独立仓库
+├── Dockerfile                      # 容器镜像定义
+├── claude-code-worker              # 宿主机 CLI（Python 脚本）
+├── install.sh                      # 一键安装脚本
+├── SPEC.md                         # 本文档
+└── container/
+    ├── entrypoint.sh               # 容器内初始化脚本
+    └── push-and-exit.sh            # 容器内自动 commit+push 脚本
+```
+
+---
+
+## 5. Dockerfile
+
+```dockerfile
+FROM ubuntu:24.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV DISABLE_AUTOUPDATER=1
+
+# 基础工具
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl wget ca-certificates gnupg2 \
+    git git-lfs \
+    build-essential make cmake \
+    python3 python3-pip python3-venv \
+    nodejs npm \
+    ttyd \
+    vim less jq tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Claude Code（native installer）
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# 确保 claude 在 PATH 中
+ENV PATH="/root/.local/bin:$PATH"
+
+# 容器内脚本
+COPY container/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY container/push-and-exit.sh /usr/local/bin/push-and-exit.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/push-and-exit.sh
+
+WORKDIR /workspace
+EXPOSE 7681
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+```
+
+---
+
+## 6. container/entrypoint.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 必要参数（由 docker run --env 传入）
+: "${WORKER_REPO_URL:?需要 WORKER_REPO_URL}"
+: "${WORKER_BRANCH:?需要 WORKER_BRANCH}"
+: "${WORKER_PURPOSE:?需要 WORKER_PURPOSE}"
+: "${WORKER_ID:?需要 WORKER_ID}"
+: "${ANTHROPIC_API_KEY:?需要 ANTHROPIC_API_KEY}"
+
+RESULT_BRANCH="result/${WORKER_PURPOSE}-$(date +%Y%m%d-%H%M%S)"
+TTYD_PORT="${TTYD_PORT:-7681}"
+
+# ── 1. Git 凭证配置 ──────────────────────────────────────────────
+if [[ -n "${GIT_TOKEN:-}" ]]; then
+    GIT_HOST=$(echo "$WORKER_REPO_URL" | sed -E 's|https?://([^/]+)/.*|\1|')
+    printf "machine %s\n  login x-access-token\n  password %s\n" \
+        "$GIT_HOST" "$GIT_TOKEN" > /root/.netrc
+    chmod 600 /root/.netrc
+fi
+
+# SSH bind-mount 时修正权限
+[[ -d /root/.ssh ]] && chmod 700 /root/.ssh 2>/dev/null || true
+
+# ── 2. 克隆并切换分支 ────────────────────────────────────────────
+echo "[worker] 克隆仓库: $WORKER_REPO_URL @ $WORKER_BRANCH"
+git clone --depth=50 --branch "$WORKER_BRANCH" "$WORKER_REPO_URL" /workspace
+cd /workspace
+
+git checkout -b "$RESULT_BRANCH"
+echo "$RESULT_BRANCH" > /tmp/result_branch_name
+
+git config user.email "claude-worker@local"
+git config user.name "Claude Worker ($WORKER_PURPOSE)"
+
+# ── 3. 写入任务上下文到 CLAUDE.md ───────────────────────────────
+cat > /workspace/CLAUDE.md << EOF
+# Worker 上下文
+
+- **任务**: $WORKER_PURPOSE
+- **源分支**: $WORKER_BRANCH
+- **结果分支**: $RESULT_BRANCH
+- **Worker ID**: $WORKER_ID
+
+完成任务后，提交代码并关闭浏览器标签即可（系统会自动 push）。
+或手动执行: push-and-exit.sh
+EOF
+
+echo "[worker] 就绪，启动 ttyd on :$TTYD_PORT"
+echo "[worker] 结果分支: $RESULT_BRANCH"
+
+# ── 4. 启动 ttyd 包装 claude ─────────────────────────────────────
+TTYD_ARGS=(--port "$TTYD_PORT" --writable --once --ping-interval 30)
+[[ -n "${TTYD_CREDENTIAL:-}" ]] && TTYD_ARGS+=(--credential "$TTYD_CREDENTIAL")
+
+ttyd "${TTYD_ARGS[@]}" \
+    bash -c "cd /workspace && exec claude --dangerously-skip-permissions --bare"
+
+# ttyd 退出后自动 push
+exec /usr/local/bin/push-and-exit.sh
+```
+
+---
+
+## 7. container/push-and-exit.sh
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace 2>/dev/null || { echo "[push] 无 /workspace，跳过"; exit 0; }
+
+RESULT_BRANCH=$(cat /tmp/result_branch_name 2>/dev/null \
+    || git rev-parse --abbrev-ref HEAD)
+
+echo "[push] 会话结束，推送分支: $RESULT_BRANCH"
+
+# 有未提交变更则自动 commit
+if git status --porcelain | grep -q .; then
+    git add -A
+    git commit -m "chore: auto-commit by claude-worker
+
+Worker: ${WORKER_ID:-unknown}
+Purpose: ${WORKER_PURPOSE:-unknown}
+Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+fi
+
+if git push origin "$RESULT_BRANCH"; then
+    echo "[push] 成功: $RESULT_BRANCH"
+    echo "pushed:$RESULT_BRANCH" > /tmp/push_status
+else
+    echo "[push] 失败！"
+    echo "failed" > /tmp/push_status
+    # 备份到 /output（如果有 bind-mount）
+    [[ -d /output ]] && tar czf /output/workspace-backup.tar.gz /workspace \
+        && echo "[push] 紧急备份已保存到 /output/workspace-backup.tar.gz"
+    exit 1
+fi
+```
+
+---
+
+## 8. claude-code-worker CLI 接口
+
+```
+用法:
+  claude-code-worker start --repo <url> --branch <branch> --purpose <purpose> [选项]
+  claude-code-worker list
+  claude-code-worker stop <worker-id> [--force]
+  claude-code-worker logs <worker-id> [-f]
+  claude-code-worker status <worker-id>
+  claude-code-worker build [--force]
+
+兼容简写（第一个参数为 --xxx 时自动视为 start）:
+  claude-code-worker --repo <url> --branch <branch> --purpose <purpose>
+
+start 选项:
+  --repo           Git 仓库 URL（SSH 或 HTTPS）
+  --branch         要检出的分支
+  --purpose        任务描述（用于命名结果分支，如 bug-fixing, feature-login）
+  --ttyd-password  ttyd Basic Auth 密码（格式: password 或 user:password）
+  --backup-dir     push 失败时的本地备份目录
+  --no-ssh         不挂载宿主机 ~/.ssh
+  --memory         容器内存限制（默认 4g）
+  --cpus           容器 CPU 限制（默认 2.0）
+```
+
+---
+
+## 9. 配置文件
+
+**`~/.claude-worker/secrets.env`**（chmod 600，不进 git）：
+```bash
+ANTHROPIC_API_KEY=sk-ant-api03-xxxx
+
+# HTTPS push 时需要（与 SSH 二选一）
+# GIT_TOKEN=ghp_xxxx
+```
+
+---
+
+## 10. 完整使用流程
+
+```bash
+# 首次安装
+cd .claude-worker && chmod +x install.sh && ./install.sh
+vim ~/.claude-worker/secrets.env    # 填入 ANTHROPIC_API_KEY
+
+# 启动 worker（按题目示例格式）
+claude-code-worker --repo git@github.com:myorg/myrepo.git \
+                   --branch release/4.0.0 \
+                   --purpose bug-fixing
+# → 输出: 🚀 Worker 就绪! 打开 http://localhost:7700
+
+# 并行启动第二个
+claude-code-worker --repo git@github.com:myorg/myrepo.git \
+                   --branch main \
+                   --purpose feature-login
+# → 输出: 🚀 Worker 就绪! 打开 http://localhost:7701
+
+# 查看所有 worker
+claude-code-worker list
+
+# 完成后停止（会自动触发 push）
+claude-code-worker stop ccw-bug-fixing-20240403120000
+```
+
+---
+
+## 11. 端口规划
+
+| 端口范围 | 用途 |
+|---|---|
+| 7700–7799 | worker ttyd 端口（自动分配，只绑定 127.0.0.1） |
+
+最多支持 100 个并行 worker。所有端口仅绑定 localhost，不对外网暴露。
+
+---
+
+## 12. 安全模型
+
+| 风险 | 缓解措施 |
+|---|---|
+| API Key 泄露 | `--env-file`（不出现在 CLI 历史），`secrets.env` chmod 600 |
+| 容器逃逸 | 不挂载 Docker socket，不给特权模式 |
+| 端口暴露 | 所有端口绑定 `127.0.0.1`，非 `0.0.0.0` |
+| 代码意外丢失 | push 失败时自动 tar 备份到 /output |
+| 容器资源失控 | `--memory 4g --cpus 2.0` 默认限制 |
+
+---
+
+## 13. 待确认事项
+
+- [ ] `claude --bare` 参数是否在 2.1.91 版本可用（需实测）
+- [ ] ttyd `--once` 行为确认：连接断开后是否触发进程退出（影响自动 push）
+- [ ] 宿主机 Docker socket 权限（当前用户是否在 docker 组）
+- [ ] 网络代理配置是否需要透传进容器（`HTTP_PROXY` 等）

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,22 +1,33 @@
 # Claude Code Worker — 设计规格（Design Spec）
 
-**版本**: 0.2（更新：加入详细环境调查结果）  
+**版本**: 0.3  
+**当前实现方案**: 方案 B — Vagrant + libvirt + Ubuntu Cloud Image  
 **目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
+
+---
+
+## 0. 方案演进路线图
+
+| 方案 | 技术栈 | 启动时间 | 隔离级别 | 状态 |
+|---|---|---|---|---|
+| **A（当前）** | Vagrant + libvirt + Ubuntu Cloud Image | 5–15 秒 | VM（独立内核） | ✅ **当前实现** |
+| B（演进） | Weaveworks Ignite（Firecracker 封装） | ~1 秒 | VM（独立内核） | 📋 待规划 |
+| C（演进） | Kata Containers（Docker CLI + VM 隔离） | 1–2 秒 | VM（独立内核） | 📋 待规划 |
+
+> 三个方案的 `entrypoint.sh`、`push-and-exit.sh`、`claude-code-worker` CLI 接口**完全复用**，
+> 只有底层 VM 启动机制不同。演进时只需替换"启动层"，不需要重写上层逻辑。
 
 ---
 
 ## 1. 当前 Claude Code Web 环境基线（经实测）
 
-> ⚠️ 注意：当前 Claude Code Web 运行环境是 **Anthropic 专有 Firecracker VM**，
-> **不是** Docker 容器，Docker daemon 未运行。
-> 本 spec 的 Docker 方案面向**用户本地 Linux 机器**，不是当前 Web 环境。
+> 此节描述 Anthropic 云端环境，作为构建本地环境的参考基准。
 
 | 项目 | 值 | 路径 |
 |---|---|---|
 | 虚拟化类型 | Firecracker VM（PID 1: /process_api --firecracker-init） | — |
 | 操作系统 | Ubuntu 24.04.4 LTS (Noble Numbat) | — |
 | 内核 | Linux 6.18.5 x86_64 | — |
-| 当前用户 | root（uid=0） | — |
 | Python | 3.11.15 | `/usr/local/bin/python3` |
 | Node.js | 22.22.2 | `/opt/node22/bin/node` |
 | Go | 1.24.7 | `/usr/local/go/bin/go` |
@@ -25,135 +36,131 @@
 | Ruby | 3.3.6 | `/usr/bin/ruby` |
 | PHP | 8.4.19 | `/usr/bin/php` |
 | Git | 2.43.0 | `/usr/bin/git` |
-| Docker CLI | 29.3.1（客户端，**无 daemon**） | `/usr/bin/docker` |
 | tmux | 3.4 | `/usr/bin/tmux` |
-| **Claude Code** | **2.1.91** | `/opt/claude-code/bin/claude`（230MB ELF 静态二进制） |
-| CPU | 4 核 | — |
-| 内存 | 15 GB（可用 ~14 GB） | — |
-| 磁盘 | 252 GB（可用 ~30 GB） | — |
+| **Claude Code** | **2.1.91** | `/opt/claude-code/bin/claude`（230MB ELF） |
+| CPU | 4 核 / 内存 15 GB / 磁盘 252 GB | — |
 
-### Claude Code 命令行关键参数（v2.1.91 实测）
+### Claude Code 关键参数（v2.1.91 实测）
 
 ```
-claude [prompt]                    # 交互式会话
-claude -p / --print                # 非交互模式（管道友好）
-claude -c / --continue             # 继续最近对话
-claude --resume [session-id]       # 恢复指定会话
-claude --worktree [name]           # 创建 git worktree
-claude --tmux                      # 在 tmux 会话中运行
-claude --dangerously-skip-permissions  # 跳过所有权限确认
-claude --settings <file>           # 自定义设置文件
-claude --output-format stream-json # 流式 JSON 输出
+claude [prompt]                       # 交互式会话
+claude -p / --print                   # 非交互模式
+claude --dangerously-skip-permissions # 跳过权限确认（VM 内安全）
+claude --tmux                         # 在 tmux 会话中运行
+claude --worktree [name]              # 创建 git worktree
+claude --settings <file>              # 自定义设置文件
 ```
 
-> ⚠️ `--bare` 参数在 v2.1.91 帮助文档中**未出现**，请勿使用。  
-> API Key 认证只需设置 `ANTHROPIC_API_KEY` 环境变量即可，无需额外参数。
-
-### apt 可用的关键包（已确认）
-
-| 包 | 版本 | 状态 |
-|---|---|---|
-| ttyd | 1.7.4-1build2 | ✅ 可安装（`apt install ttyd`） |
-| supervisor | 4.2.5-1ubuntu0.1 | ✅ 可安装 |
-| openssh-server | 9.6p1 | ✅ 可安装 |
+> ⚠️ `--bare` 在 v2.1.91 中不存在。认证只需设 `ANTHROPIC_API_KEY` 环境变量。
 
 ---
 
-## 2. 系统架构
+## 2. 方案 A：Vagrant + libvirt + Ubuntu Cloud Image（当前实现）
+
+### 2.1 架构总览
 
 ```
-用户本地 Linux 机器（有 Docker daemon）
+用户本地 Linux 机器（有 KVM + vagrant-libvirt）
 │
-├── claude-code-worker CLI         ← 宿主机管理脚本
+├── claude-code-worker CLI
 │   ├── start --repo --branch --purpose
-│   ├── list
-│   ├── stop <id>
-│   ├── logs <id>
-│   └── build
+│   ├── list / stop / logs / status
+│   └── build-box（构建 golden box，首次或更新时用）
 │
 ├── ~/.claude-worker/
-│   ├── secrets.env                ← ANTHROPIC_API_KEY 等（chmod 600，不进 git）
-│   └── workers.json               ← 运行状态记录
+│   ├── secrets.env                  ← 敏感信息（chmod 600，不进 git）
+│   ├── workers.json                 ← 运行状态
+│   ├── boxes/
+│   │   └── claude-worker.box        ← golden box（预装所有工具）
+│   └── instances/
+│       ├── ccw-bug-fixing-xxx/
+│       │   ├── Vagrantfile          ← 动态生成，含端口和参数
+│       │   └── .vagrant/
+│       └── ccw-feature-dev-xxx/
+│           └── ...
 │
-└── Docker Containers（隔离）
+└── Vagrant VMs（KVM 隔离）
     ├── ccw-bug-fixing-xxx  :7700  → http://localhost:7700
     ├── ccw-feature-dev-xxx :7701  → http://localhost:7701
     └── ccw-refactor-xxx    :7702  → http://localhost:7702
 ```
 
-每个容器内部：
+### 2.2 Golden Box 策略（核心性能优化）
+
+**为什么需要 golden box：**
+每次 `vagrant up` 从头 provision（装 Claude Code）需要 3–5 分钟。
+Golden box 把这步变成一次性工作，之后每次启动只需 5–15 秒。
+
+**构建流程：**
 ```
-容器内
-├── entrypoint.sh
-│   ├── 配置 git 凭证（SSH mount 或 ~/.netrc token）
-│   ├── git clone --depth=50 --branch <BRANCH> <REPO>
-│   ├── git checkout -b result/<PURPOSE>-<timestamp>
-│   └── 启动 ttyd :7681 → 包装 claude CLI
-│
-└── 用户浏览器 → ttyd WebSocket → claude TUI
+Ubuntu 24.04 cloud image (generic/ubuntu2404 libvirt box)
+    ↓ vagrant up + provision（一次性，约 5 分钟）
+    装：git, python3, nodejs, go, ttyd, claude, 开发工具
+    ↓ vagrant package --output claude-worker.box
+    ↓ vagrant box add claude-worker ./claude-worker.box
+claude-worker.box（本地 golden box）
+    ↓ 每次 worker start（无 provision）
+    5–15 秒内就绪
 ```
 
----
+**命令：**
+```bash
+claude-code-worker build-box          # 构建/重建 golden box（约 5 分钟，只需偶尔执行）
+claude-code-worker build-box --force  # 强制重建（更新 Claude Code 版本时用）
+```
 
-## 3. 技术选型说明
-
-### 3.1 为什么用 ttyd
-
-Claude Code 是**静态编译的 TUI 二进制**（230MB ELF），没有内置 HTTP web server。  
-`ttyd 1.7.4` 在 Ubuntu 24.04 官方源中，`apt install ttyd` 直接安装，将终端包装为 WebSocket + WebGL 的浏览器界面。
-
-### 3.2 Claude Code 安装方式
+### 2.3 前置依赖
 
 ```bash
-# 正确方式（native installer，v2.1.91）
-DISABLE_AUTOUPDATER=1 curl -fsSL https://claude.ai/install.sh | bash
-# 安装后位于 /root/.local/bin/claude 或 /opt/claude-code/bin/claude
+# 宿主机需要安装
+sudo apt install qemu-kvm libvirt-daemon-system vagrant
+vagrant plugin install vagrant-libvirt
 
-# ❌ 已弃用，勿用
-npm install -g @anthropic-ai/claude-code
+# 确认 KVM 可用
+kvm-ok
+virsh list --all
 ```
 
-`DISABLE_AUTOUPDATER=1` 是 Docker 场景**必要参数**，否则安装会卡住。
-
-### 3.3 认证
-
-只需设置环境变量，无需交互登录：
-```bash
-ANTHROPIC_API_KEY=sk-ant-xxxx
-```
-通过 `docker run --env-file` 传入，不出现在命令行历史中。
-
-### 3.4 Git 凭证（两种，自动检测）
-
-- **SSH**（推荐）：`~/.ssh` bind-mount 只读进容器
-- **HTTPS Token**：`GIT_TOKEN` 环境变量 → 容器内写入 `~/.netrc`
-
----
-
-## 4. 文件结构
+### 2.4 文件结构
 
 ```
 .claude-worker/
-├── Dockerfile
-├── claude-code-worker              # 宿主机 CLI（Python）
-├── install.sh
 ├── SPEC.md
-└── container/
-    ├── entrypoint.sh               # 容器内初始化
-    └── push-and-exit.sh            # 容器内自动 commit + push
+├── claude-code-worker          # 宿主机 CLI（Python）
+├── install.sh                  # 一键安装脚本
+├── build-box/
+│   ├── Vagrantfile             # Golden box 构建用
+│   └── provision.sh            # 工具安装脚本（apt + claude + ttyd）
+└── vm/
+    ├── Vagrantfile.tmpl        # Worker VM 模板（动态生成）
+    ├── entrypoint.sh           # VM 内初始化脚本
+    └── push-and-exit.sh        # VM 内自动 commit + push
 ```
 
----
+### 2.5 build-box/Vagrantfile
 
-## 5. Dockerfile
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/ubuntu2404"
+  config.vm.provider :libvirt do |lv|
+    lv.memory = 4096
+    lv.cpus   = 2
+    lv.driver = "kvm"
+  end
 
-```dockerfile
-FROM ubuntu:24.04
+  config.vm.provision "shell", path: "provision.sh"
+end
+```
 
-ARG DEBIAN_FRONTEND=noninteractive
-ENV DISABLE_AUTOUPDATER=1
+### 2.6 build-box/provision.sh
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+export DISABLE_AUTOUPDATER=1
+
+apt-get update && apt-get install -y --no-install-recommends \
     curl wget ca-certificates gnupg2 \
     git git-lfs \
     build-essential make cmake \
@@ -164,24 +171,64 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Claude Code（native installer）
-RUN curl -fsSL https://claude.ai/install.sh | bash
+curl -fsSL https://claude.ai/install.sh | bash
 
-# claude 可能安装到 ~/.local/bin 或 /opt/claude-code/bin
-ENV PATH="/root/.local/bin:/opt/claude-code/bin:$PATH"
+# 确保 claude 在全局 PATH
+CLAUDE_BIN=$(find /root/.local/bin /opt/claude-code/bin -name claude 2>/dev/null | head -1)
+ln -sf "$CLAUDE_BIN" /usr/local/bin/claude
 
-COPY container/entrypoint.sh /usr/local/bin/entrypoint.sh
-COPY container/push-and-exit.sh /usr/local/bin/push-and-exit.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/push-and-exit.sh
+# 验证安装
+claude --version
 
-WORKDIR /workspace
-EXPOSE 7681
+# 写入 entrypoint 和 push 脚本
+cp /vagrant/../vm/entrypoint.sh /usr/local/bin/entrypoint.sh
+cp /vagrant/../vm/push-and-exit.sh /usr/local/bin/push-and-exit.sh
+chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/push-and-exit.sh
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+echo "[provision] Golden box 构建完成"
 ```
 
----
+### 2.7 vm/Vagrantfile.tmpl
 
-## 6. container/entrypoint.sh
+每个 worker 动态生成，`{{占位符}}` 由 CLI 替换：
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.box = "claude-worker"   # 使用本地 golden box
+
+  config.vm.network "forwarded_port",
+    guest: 7681,
+    host:  {{HOST_PORT}},
+    host_ip: "127.0.0.1"            # 只绑定 localhost，不对外暴露
+
+  config.vm.provider :libvirt do |lv|
+    lv.memory = {{MEMORY_MB}}
+    lv.cpus   = {{CPUS}}
+    lv.driver = "kvm"
+  end
+
+  # SSH key 只读挂载（用于 git push）
+  config.vm.synced_folder "~/.ssh", "/root/.ssh",
+    type: "rsync",
+    rsync__exclude: [],
+    rsync__args: ["--chmod=D700,F600"]
+
+  # 注入环境变量并启动 ttyd + claude
+  config.vm.provision "shell", run: "always", env: {
+    "ANTHROPIC_API_KEY" => ENV["ANTHROPIC_API_KEY"] || "",
+    "GIT_TOKEN"         => ENV["GIT_TOKEN"] || "",
+    "WORKER_ID"         => "{{WORKER_ID}}",
+    "WORKER_REPO_URL"   => "{{REPO_URL}}",
+    "WORKER_BRANCH"     => "{{BRANCH}}",
+    "WORKER_PURPOSE"    => "{{PURPOSE}}",
+  }, inline: "/usr/local/bin/entrypoint.sh"
+end
+```
+
+> **安全说明**：`ENV["ANTHROPIC_API_KEY"]` 在 CLI 执行时从宿主机 `secrets.env` 读取并注入，
+> 不写入 Vagrantfile 文件本身（Vagrantfile 是动态生成的临时文件，存于 `~/.claude-worker/instances/` 下）。
+
+### 2.8 vm/entrypoint.sh
 
 ```bash
 #!/usr/bin/env bash
@@ -193,17 +240,22 @@ set -euo pipefail
 : "${WORKER_ID:?需要 WORKER_ID}"
 : "${ANTHROPIC_API_KEY:?需要 ANTHROPIC_API_KEY}"
 
+# 写入全局环境（使 ttyd 启动的子进程也能读取）
+cat >> /etc/environment << EOF
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+EOF
+
 RESULT_BRANCH="result/${WORKER_PURPOSE}-$(date +%Y%m%d-%H%M%S)"
 TTYD_PORT="${TTYD_PORT:-7681}"
 
-# git 凭证
+# Git 凭证（HTTPS token 方式）
 if [[ -n "${GIT_TOKEN:-}" ]]; then
     GIT_HOST=$(echo "$WORKER_REPO_URL" | sed -E 's|https?://([^/]+)/.*|\1|')
     printf "machine %s\n  login x-access-token\n  password %s\n" \
         "$GIT_HOST" "$GIT_TOKEN" > /root/.netrc
     chmod 600 /root/.netrc
 fi
-[[ -d /root/.ssh ]] && chmod 700 /root/.ssh 2>/dev/null || true
+# SSH 方式：rsync 挂载的 ~/.ssh 已经就位
 
 # 克隆并切换分支
 git clone --depth=50 --branch "$WORKER_BRANCH" "$WORKER_REPO_URL" /workspace
@@ -224,20 +276,19 @@ cat > /workspace/CLAUDE.md << EOF
 完成后关闭浏览器标签，系统会自动 commit + push。
 EOF
 
-echo "[worker] 就绪，启动 ttyd :$TTYD_PORT，结果分支: $RESULT_BRANCH"
+echo "[worker] 启动 ttyd :$TTYD_PORT，结果分支: $RESULT_BRANCH"
 
 TTYD_ARGS=(--port "$TTYD_PORT" --writable --once --ping-interval 30)
 [[ -n "${TTYD_CREDENTIAL:-}" ]] && TTYD_ARGS+=(--credential "$TTYD_CREDENTIAL")
 
-# 启动 ttyd，会话结束后自动 push
 ttyd "${TTYD_ARGS[@]}" \
     bash -c "cd /workspace && exec claude --dangerously-skip-permissions"
+
+# ttyd 退出后自动 push
 exec /usr/local/bin/push-and-exit.sh
 ```
 
----
-
-## 7. container/push-and-exit.sh
+### 2.9 vm/push-and-exit.sh
 
 ```bash
 #!/usr/bin/env bash
@@ -265,109 +316,176 @@ if git push origin "$RESULT_BRANCH"; then
 else
     echo "[push] 失败！"
     echo "failed" > /tmp/push_status
-    [[ -d /output ]] && tar czf /output/workspace-backup.tar.gz /workspace \
-        && echo "[push] 备份已保存到 /output/workspace-backup.tar.gz"
+    # 备份到宿主机共享目录（如有）
+    [[ -d /vagrant-backup ]] && \
+        tar czf /vagrant-backup/workspace-backup-$(date +%s).tar.gz /workspace
     exit 1
 fi
 ```
 
----
-
-## 8. claude-code-worker CLI 接口
+### 2.10 claude-code-worker CLI 接口
 
 ```
 用法:
   claude-code-worker start --repo <url> --branch <branch> --purpose <purpose> [选项]
   claude-code-worker list
   claude-code-worker stop <id> [--force]
-  claude-code-worker logs <id> [-f]
+  claude-code-worker logs <id>
   claude-code-worker status <id>
-  claude-code-worker build [--force]
+  claude-code-worker build-box [--force]   ← 构建 golden box（首次必须）
 
-# 兼容简写（与 start 等价）:
+# 兼容简写:
   claude-code-worker --repo <url> --branch <branch> --purpose <purpose>
 
 start 选项:
-  --ttyd-password  ttyd Basic Auth（格式: password 或 user:password）
-  --backup-dir     push 失败时的本地备份目录
-  --no-ssh         不挂载 ~/.ssh
-  --memory         容器内存限制（默认 4g）
-  --cpus           CPU 限制（默认 2.0）
+  --ttyd-password  ttyd Basic Auth 密码
+  --memory         VM 内存（默认 2048，单位 MB）
+  --cpus           VM CPU 数（默认 2）
+  --no-ssh         不同步 ~/.ssh 进 VM
 ```
 
----
-
-## 9. 配置文件
+### 2.11 配置文件
 
 **`~/.claude-worker/secrets.env`**（chmod 600，不进 git）：
 ```bash
 ANTHROPIC_API_KEY=sk-ant-api03-xxxx
-
-# HTTPS push 时使用（与 SSH 二选一）
-# GIT_TOKEN=ghp_xxxx
+# GIT_TOKEN=ghp_xxxx   # HTTPS push 时使用
 ```
 
----
+CLI 启动时自动 `source` 此文件，通过 Vagrantfile `env:` 注入 VM。
 
-## 10. 端口规划
+### 2.12 端口规划
 
-| 端口范围 | 绑定地址 | 用途 |
+| 范围 | 绑定 | 说明 |
 |---|---|---|
-| 7700–7799 | 127.0.0.1 | worker ttyd（自动分配，最多 100 个并行） |
+| 7700–7799 | 127.0.0.1 | worker ttyd 端口，最多 100 个并行 |
 
----
-
-## 11. 安全模型
+### 2.13 安全模型
 
 | 风险 | 缓解措施 |
 |---|---|
-| API Key 泄露 | `--env-file`（不出现在命令行），`secrets.env` chmod 600 |
-| 容器逃逸 | 不挂载 Docker socket，无特权模式 |
-| 端口暴露 | 全部绑定 `127.0.0.1`，非 `0.0.0.0` |
-| 代码丢失 | push 失败时自动 tar 备份到 /output |
-| 资源失控 | `--memory 4g --cpus 2.0` 默认限制 |
+| API Key 泄露 | `secrets.env` chmod 600，通过 Vagrant `env:` 注入（不写入文件） |
+| VM 逃逸 | KVM 硬件隔离，不共享内核 |
+| 端口暴露 | 全部绑定 `127.0.0.1` |
+| 代码丢失 | push 失败时备份到宿主机共享目录 |
+| 资源失控 | libvirt memory/cpus 限制 |
 
----
-
-## 12. 完整使用流程
+### 2.14 完整使用流程
 
 ```bash
-# 安装
+# === 首次安装（只需一次）===
 cd .claude-worker && chmod +x install.sh && ./install.sh
+# 安装 vagrant-libvirt plugin，注册脚本到 PATH
+
 vim ~/.claude-worker/secrets.env   # 填入 ANTHROPIC_API_KEY
 
-# 启动
+claude-code-worker build-box       # 构建 golden box（约 5 分钟）
+
+# === 日常使用 ===
 claude-code-worker --repo git@github.com:org/repo.git \
                    --branch release/4.0.0 \
                    --purpose bug-fixing
-# → 🚀 就绪! http://localhost:7700
+# → [info] 启动 VM ccw-bug-fixing-20240403120000...
+# → [ready] 打开 http://localhost:7700
 
 # 并行第二个
 claude-code-worker --repo git@github.com:org/repo.git \
                    --branch main \
                    --purpose feature-login
-# → 🚀 就绪! http://localhost:7701
+# → [ready] 打开 http://localhost:7701
 
 claude-code-worker list
+# WORKER ID                          PORT   BRANCH          PURPOSE
+# ccw-bug-fixing-20240403120000      7700   release/4.0.0   bug-fixing
+# ccw-feature-login-20240403120100   7701   main            feature-login
+
 claude-code-worker stop ccw-bug-fixing-20240403120000
+# → [info] 触发 push...
+# → [push] 成功: result/bug-fixing-20240403-120001
+# → [info] VM 已销毁
 ```
 
+### 2.15 待确认事项（本地机器实测）
+
+- [ ] `claude --dangerously-skip-permissions` 在 VM 内首次运行是否还需要交互确认？
+      → 若需要，在 provision.sh 中预先运行一次 `echo "" | claude --print "hello"` 完成初始化
+- [ ] `ttyd --once` 在连接断开后是否立即退出进程？
+      → 若不立即退出，改用 `ttyd --once --exit-on-disconnect`（如支持）或用 trap 处理
+- [ ] golden box 中 claude 安装路径：`/root/.local/bin/` 还是 `/opt/claude-code/bin/`？
+      → provision.sh 用 `find` 自动定位并建 symlink，已处理
+- [ ] SSH rsync 到 VM 时权限是否正确？
+      → 已在 Vagrantfile 中指定 `--chmod=D700,F600`，实测确认
+
 ---
 
-## 13. 待确认事项（需在用户本地机器实测）
+## 3. 方案 B（演进）：Weaveworks Ignite — Firecracker 封装
 
-- [ ] `claude --dangerously-skip-permissions` 在容器内首次运行时是否会提示 OAuth？（若会，需先在 Dockerfile 内 pre-auth）
-- [ ] `ttyd --once` 连接断开后是否立即触发进程退出？（影响自动 push 时机）
-- [ ] native installer 在 Ubuntu 24.04 Docker 容器内安装路径：`/root/.local/bin/claude` 还是 `/opt/claude-code/bin/claude`？
-- [ ] 网络代理环境变量（`HTTP_PROXY` 等）是否需要透传进容器？
+> 📋 规划阶段，暂不实现。当方案 A 满足不了启动速度需求时迁移。
+
+**核心优势**：启动时间 ~1 秒，接近 Anthropic 云端体验。
+
+**原理**：
+```
+ignite run ubuntu  →  Firecracker VMM  →  KVM  →  microVM（125ms 启动）
+```
+Ignite 提供类 Docker 的 CLI，但底层每个"容器"是一个真正的 VM。
+
+**前置依赖**：
+```bash
+# 需要 KVM（已有），额外安装：
+curl -fsSL https://github.com/weaveworks/ignite/releases/latest/download/ignite-amd64 \
+    -o /usr/local/bin/ignite && chmod +x /usr/local/bin/ignite
+
+# containerd（Ignite 依赖）
+sudo apt install containerd
+```
+
+**与方案 A 的差异**：
+- 启动命令：`ignite run claude-worker:latest --name ccw-xxx --ports 7700:7681`（替换 `vagrant up`）
+- 停止命令：`ignite stop ccw-xxx && ignite rm ccw-xxx`（替换 `vagrant destroy`）
+- Golden image：用 `ignite build` 替换 `vagrant package`
+- `entrypoint.sh`、`push-and-exit.sh`、CLI 接口**完全不变**
+
+**迁移成本**：仅替换 `claude-code-worker` CLI 中的 ~50 行启动/停止逻辑。
 
 ---
 
-## 14. 备注：当前 Firecracker 环境替代方案
+## 4. 方案 C（演进）：Kata Containers — Docker CLI + VM 隔离
 
-当前 Claude Code Web 环境无 Docker daemon，若需在此环境测试并行，可用：
-- **tmux** (`/usr/bin/tmux 3.4`，已安装）创建多个 tmux session
-- **ttyd**（`apt install ttyd`）对外暴露各 session
-- 每个 tmux session 对应一个 git worktree
+> 📋 规划阶段，暂不实现。适合团队共享 CI/CD 场景。
 
-但这种方式隔离性弱（共享同一文件系统和进程空间），仅适合轻量测试。
+**核心优势**：对外呈现标准 Docker 接口，底层每个容器是 KVM microVM，1–2 秒启动。
+
+**原理**：
+```
+docker run  →  containerd  →  Kata shim  →  QEMU/Firecracker  →  KVM  →  microVM
+```
+
+**前置依赖**：
+```bash
+sudo apt install kata-containers
+# 配置 Docker/containerd 使用 kata runtime
+```
+
+**与方案 A 的差异**：
+- 启动命令：`docker run --runtime=kata-runtime ...`（回归 Docker 接口）
+- 构建：`docker build`（替换 `vagrant package`）
+- `entrypoint.sh`、`push-and-exit.sh`、CLI 接口**完全不变**
+
+**适用场景**：多人团队、有 Docker Registry、需要 CI/CD 集成时优先选择。
+
+---
+
+## 5. 三方案对比
+
+| | 方案 A（当前）| 方案 B（演进）| 方案 C（演进）|
+|---|---|---|---|
+| **技术** | Vagrant + libvirt | Weaveworks Ignite | Kata Containers |
+| **CLI** | vagrant | ignite | docker |
+| **启动时间** | 5–15 秒 | ~1 秒 | 1–2 秒 |
+| **隔离** | KVM VM | Firecracker VM | QEMU/Firecracker VM |
+| **前置依赖** | KVM + Vagrant（已有） | KVM + containerd | Docker + KVM |
+| **镜像格式** | .box | OCI image | Docker image |
+| **Docker Registry** | 不需要 | 不需要 | 可选 |
+| **团队共享** | 困难（.box 文件大） | 中等 | 容易（Registry） |
+| **迁移成本** | — | 低（替换 ~50 行） | 低（替换 ~50 行） |

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,44 +1,70 @@
 # Claude Code Worker — 设计规格（Design Spec）
 
-**版本**: 0.1  
+**版本**: 0.2（更新：加入详细环境调查结果）  
 **目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
 
 ---
 
-## 1. 当前环境基线（经实测）
+## 1. 当前 Claude Code Web 环境基线（经实测）
 
-构建 Docker 镜像的基础参考当前运行环境：
+> ⚠️ 注意：当前 Claude Code Web 运行环境是 **Anthropic 专有 Firecracker VM**，
+> **不是** Docker 容器，Docker daemon 未运行。
+> 本 spec 的 Docker 方案面向**用户本地 Linux 机器**，不是当前 Web 环境。
 
-| 项目 | 值 |
-|---|---|
-| 基础镜像 | Ubuntu 24.04.4 LTS (Noble Numbat) |
-| 内核 | Linux 6.18.5 x86_64 |
-| Python | 3.11.15（`/usr/local/bin/python3`） |
-| Node.js | 22.22.2（`/opt/node22/bin/node`） |
-| Go | 1.24.7（`/usr/local/go/bin/go`） |
-| Rust | 1.94.1（`/root/.cargo/bin/rustc`） |
-| Java | 已安装（JDK） |
-| Ruby | 已安装 |
-| PHP | 8.4 |
-| Git | 2.43.0 |
-| Docker | 29.3.1（宿主机可用） |
-| Claude Code | 2.1.91（`/root/.local/bin/claude`，native installer） |
-| CPU | 4 核 |
-| 内存 | 15 GB |
-| 磁盘 | 252 GB，可用 ~31 GB |
+| 项目 | 值 | 路径 |
+|---|---|---|
+| 虚拟化类型 | Firecracker VM（PID 1: /process_api --firecracker-init） | — |
+| 操作系统 | Ubuntu 24.04.4 LTS (Noble Numbat) | — |
+| 内核 | Linux 6.18.5 x86_64 | — |
+| 当前用户 | root（uid=0） | — |
+| Python | 3.11.15 | `/usr/local/bin/python3` |
+| Node.js | 22.22.2 | `/opt/node22/bin/node` |
+| Go | 1.24.7 | `/usr/local/go/bin/go` |
+| Rust | 1.94.1 | `/usr/bin/rustc` |
+| Java | OpenJDK 21.0.10 | `/usr/bin/java` |
+| Ruby | 3.3.6 | `/usr/bin/ruby` |
+| PHP | 8.4.19 | `/usr/bin/php` |
+| Git | 2.43.0 | `/usr/bin/git` |
+| Docker CLI | 29.3.1（客户端，**无 daemon**） | `/usr/bin/docker` |
+| tmux | 3.4 | `/usr/bin/tmux` |
+| **Claude Code** | **2.1.91** | `/opt/claude-code/bin/claude`（230MB ELF 静态二进制） |
+| CPU | 4 核 | — |
+| 内存 | 15 GB（可用 ~14 GB） | — |
+| 磁盘 | 252 GB（可用 ~30 GB） | — |
 
-**关键约束**：
-- 网络出站通过 Anthropic 托管代理过滤，仅允许白名单域名（PyPI、npm、GitHub、crates.io、apt.ubuntu.com 等已在白名单内）
-- 宿主机已有 Docker socket 和 Docker CLI
+### Claude Code 命令行关键参数（v2.1.91 实测）
+
+```
+claude [prompt]                    # 交互式会话
+claude -p / --print                # 非交互模式（管道友好）
+claude -c / --continue             # 继续最近对话
+claude --resume [session-id]       # 恢复指定会话
+claude --worktree [name]           # 创建 git worktree
+claude --tmux                      # 在 tmux 会话中运行
+claude --dangerously-skip-permissions  # 跳过所有权限确认
+claude --settings <file>           # 自定义设置文件
+claude --output-format stream-json # 流式 JSON 输出
+```
+
+> ⚠️ `--bare` 参数在 v2.1.91 帮助文档中**未出现**，请勿使用。  
+> API Key 认证只需设置 `ANTHROPIC_API_KEY` 环境变量即可，无需额外参数。
+
+### apt 可用的关键包（已确认）
+
+| 包 | 版本 | 状态 |
+|---|---|---|
+| ttyd | 1.7.4-1build2 | ✅ 可安装（`apt install ttyd`） |
+| supervisor | 4.2.5-1ubuntu0.1 | ✅ 可安装 |
+| openssh-server | 9.6p1 | ✅ 可安装 |
 
 ---
 
 ## 2. 系统架构
 
 ```
-宿主机 (用户的 Linux 电脑)
+用户本地 Linux 机器（有 Docker daemon）
 │
-├── claude-code-worker CLI          ← 宿主机上运行的管理脚本
+├── claude-code-worker CLI         ← 宿主机管理脚本
 │   ├── start --repo --branch --purpose
 │   ├── list
 │   ├── stop <id>
@@ -46,70 +72,75 @@
 │   └── build
 │
 ├── ~/.claude-worker/
-│   ├── secrets.env                 ← API Key 等敏感信息（chmod 600，不进 git）
-│   └── workers.json                ← 运行中 worker 的状态记录
+│   ├── secrets.env                ← ANTHROPIC_API_KEY 等（chmod 600，不进 git）
+│   └── workers.json               ← 运行状态记录
 │
-└── Docker Containers (隔离)
-    ├── ccw-bug-fixing-xxx  :7700  → 浏览器访问 http://localhost:7700
-    ├── ccw-feature-dev-xxx :7701  → 浏览器访问 http://localhost:7701
-    └── ccw-refactor-xxx    :7702  → 浏览器访问 http://localhost:7702
+└── Docker Containers（隔离）
+    ├── ccw-bug-fixing-xxx  :7700  → http://localhost:7700
+    ├── ccw-feature-dev-xxx :7701  → http://localhost:7701
+    └── ccw-refactor-xxx    :7702  → http://localhost:7702
 ```
 
 每个容器内部：
 ```
 容器内
-├── entrypoint.sh（初始化）
-│   ├── 配置 git 凭证（SSH mount 或 HTTPS token）
+├── entrypoint.sh
+│   ├── 配置 git 凭证（SSH mount 或 ~/.netrc token）
 │   ├── git clone --depth=50 --branch <BRANCH> <REPO>
 │   ├── git checkout -b result/<PURPOSE>-<timestamp>
-│   └── 启动 ttyd → 包装 claude CLI
+│   └── 启动 ttyd :7681 → 包装 claude CLI
 │
-└── ttyd --port 7681
-    └── bash -c "cd /workspace && claude --dangerously-skip-permissions"
-        ← 用户通过浏览器操作这个终端
+└── 用户浏览器 → ttyd WebSocket → claude TUI
 ```
 
 ---
 
 ## 3. 技术选型说明
 
-### 3.1 为什么用 ttyd 而不是内置 web 模式
+### 3.1 为什么用 ttyd
 
-Claude Code **没有**内置 HTTP web server 模式——它是一个 TUI 二进制程序。  
-`ttyd` 是 Ubuntu 24.04 apt 官方源中的 `1.7.4` 版本，`apt install ttyd` 即可安装，无需编译。它将任意终端命令包装成 WebSocket + WebGL 的浏览器终端，是最简单且已在生产环境验证的方案。
+Claude Code 是**静态编译的 TUI 二进制**（230MB ELF），没有内置 HTTP web server。  
+`ttyd 1.7.4` 在 Ubuntu 24.04 官方源中，`apt install ttyd` 直接安装，将终端包装为 WebSocket + WebGL 的浏览器界面。
 
 ### 3.2 Claude Code 安装方式
 
-使用官方 native installer（npm 方式已弃用）：
 ```bash
+# 正确方式（native installer，v2.1.91）
 DISABLE_AUTOUPDATER=1 curl -fsSL https://claude.ai/install.sh | bash
+# 安装后位于 /root/.local/bin/claude 或 /opt/claude-code/bin/claude
+
+# ❌ 已弃用，勿用
+npm install -g @anthropic-ai/claude-code
 ```
-`DISABLE_AUTOUPDATER=1` 防止容器内安装卡住，这是 Docker 场景的必要参数。
 
-### 3.3 认证方式
+`DISABLE_AUTOUPDATER=1` 是 Docker 场景**必要参数**，否则安装会卡住。
 
-- **API Key**（推荐）：通过 `ANTHROPIC_API_KEY` 环境变量传入，配合 `claude --bare` 参数强制使用 API Key 认证，跳过 OAuth 流程。
-- **OAuth 登录**（备选）：需要交互式浏览器认证，不适合容器化场景。
+### 3.3 认证
 
-### 3.4 Git 凭证
+只需设置环境变量，无需交互登录：
+```bash
+ANTHROPIC_API_KEY=sk-ant-xxxx
+```
+通过 `docker run --env-file` 传入，不出现在命令行历史中。
 
-两种方式，自动检测：
-- **SSH**（推荐）：将宿主机 `~/.ssh` bind-mount 进容器（只读）
-- **HTTPS Token**：通过 `GIT_TOKEN` 环境变量传入，容器内写入 `~/.netrc`
+### 3.4 Git 凭证（两种，自动检测）
+
+- **SSH**（推荐）：`~/.ssh` bind-mount 只读进容器
+- **HTTPS Token**：`GIT_TOKEN` 环境变量 → 容器内写入 `~/.netrc`
 
 ---
 
 ## 4. 文件结构
 
 ```
-.claude-worker/                     ← 放在项目根目录或独立仓库
-├── Dockerfile                      # 容器镜像定义
-├── claude-code-worker              # 宿主机 CLI（Python 脚本）
-├── install.sh                      # 一键安装脚本
-├── SPEC.md                         # 本文档
+.claude-worker/
+├── Dockerfile
+├── claude-code-worker              # 宿主机 CLI（Python）
+├── install.sh
+├── SPEC.md
 └── container/
-    ├── entrypoint.sh               # 容器内初始化脚本
-    └── push-and-exit.sh            # 容器内自动 commit+push 脚本
+    ├── entrypoint.sh               # 容器内初始化
+    └── push-and-exit.sh            # 容器内自动 commit + push
 ```
 
 ---
@@ -122,7 +153,6 @@ FROM ubuntu:24.04
 ARG DEBIAN_FRONTEND=noninteractive
 ENV DISABLE_AUTOUPDATER=1
 
-# 基础工具
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl wget ca-certificates gnupg2 \
     git git-lfs \
@@ -136,10 +166,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Claude Code（native installer）
 RUN curl -fsSL https://claude.ai/install.sh | bash
 
-# 确保 claude 在 PATH 中
-ENV PATH="/root/.local/bin:$PATH"
+# claude 可能安装到 ~/.local/bin 或 /opt/claude-code/bin
+ENV PATH="/root/.local/bin:/opt/claude-code/bin:$PATH"
 
-# 容器内脚本
 COPY container/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY container/push-and-exit.sh /usr/local/bin/push-and-exit.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/push-and-exit.sh
@@ -158,7 +187,6 @@ ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 #!/usr/bin/env bash
 set -euo pipefail
 
-# 必要参数（由 docker run --env 传入）
 : "${WORKER_REPO_URL:?需要 WORKER_REPO_URL}"
 : "${WORKER_BRANCH:?需要 WORKER_BRANCH}"
 : "${WORKER_PURPOSE:?需要 WORKER_PURPOSE}"
@@ -168,52 +196,42 @@ set -euo pipefail
 RESULT_BRANCH="result/${WORKER_PURPOSE}-$(date +%Y%m%d-%H%M%S)"
 TTYD_PORT="${TTYD_PORT:-7681}"
 
-# ── 1. Git 凭证配置 ──────────────────────────────────────────────
+# git 凭证
 if [[ -n "${GIT_TOKEN:-}" ]]; then
     GIT_HOST=$(echo "$WORKER_REPO_URL" | sed -E 's|https?://([^/]+)/.*|\1|')
     printf "machine %s\n  login x-access-token\n  password %s\n" \
         "$GIT_HOST" "$GIT_TOKEN" > /root/.netrc
     chmod 600 /root/.netrc
 fi
-
-# SSH bind-mount 时修正权限
 [[ -d /root/.ssh ]] && chmod 700 /root/.ssh 2>/dev/null || true
 
-# ── 2. 克隆并切换分支 ────────────────────────────────────────────
-echo "[worker] 克隆仓库: $WORKER_REPO_URL @ $WORKER_BRANCH"
+# 克隆并切换分支
 git clone --depth=50 --branch "$WORKER_BRANCH" "$WORKER_REPO_URL" /workspace
 cd /workspace
-
 git checkout -b "$RESULT_BRANCH"
 echo "$RESULT_BRANCH" > /tmp/result_branch_name
-
 git config user.email "claude-worker@local"
 git config user.name "Claude Worker ($WORKER_PURPOSE)"
 
-# ── 3. 写入任务上下文到 CLAUDE.md ───────────────────────────────
+# 写入任务上下文
 cat > /workspace/CLAUDE.md << EOF
 # Worker 上下文
-
 - **任务**: $WORKER_PURPOSE
 - **源分支**: $WORKER_BRANCH
 - **结果分支**: $RESULT_BRANCH
 - **Worker ID**: $WORKER_ID
 
-完成任务后，提交代码并关闭浏览器标签即可（系统会自动 push）。
-或手动执行: push-and-exit.sh
+完成后关闭浏览器标签，系统会自动 commit + push。
 EOF
 
-echo "[worker] 就绪，启动 ttyd on :$TTYD_PORT"
-echo "[worker] 结果分支: $RESULT_BRANCH"
+echo "[worker] 就绪，启动 ttyd :$TTYD_PORT，结果分支: $RESULT_BRANCH"
 
-# ── 4. 启动 ttyd 包装 claude ─────────────────────────────────────
 TTYD_ARGS=(--port "$TTYD_PORT" --writable --once --ping-interval 30)
 [[ -n "${TTYD_CREDENTIAL:-}" ]] && TTYD_ARGS+=(--credential "$TTYD_CREDENTIAL")
 
+# 启动 ttyd，会话结束后自动 push
 ttyd "${TTYD_ARGS[@]}" \
-    bash -c "cd /workspace && exec claude --dangerously-skip-permissions --bare"
-
-# ttyd 退出后自动 push
+    bash -c "cd /workspace && exec claude --dangerously-skip-permissions"
 exec /usr/local/bin/push-and-exit.sh
 ```
 
@@ -230,9 +248,8 @@ cd /workspace 2>/dev/null || { echo "[push] 无 /workspace，跳过"; exit 0; }
 RESULT_BRANCH=$(cat /tmp/result_branch_name 2>/dev/null \
     || git rev-parse --abbrev-ref HEAD)
 
-echo "[push] 会话结束，推送分支: $RESULT_BRANCH"
+echo "[push] 会话结束，推送: $RESULT_BRANCH"
 
-# 有未提交变更则自动 commit
 if git status --porcelain | grep -q .; then
     git add -A
     git commit -m "chore: auto-commit by claude-worker
@@ -248,9 +265,8 @@ if git push origin "$RESULT_BRANCH"; then
 else
     echo "[push] 失败！"
     echo "failed" > /tmp/push_status
-    # 备份到 /output（如果有 bind-mount）
     [[ -d /output ]] && tar czf /output/workspace-backup.tar.gz /workspace \
-        && echo "[push] 紧急备份已保存到 /output/workspace-backup.tar.gz"
+        && echo "[push] 备份已保存到 /output/workspace-backup.tar.gz"
     exit 1
 fi
 ```
@@ -263,23 +279,20 @@ fi
 用法:
   claude-code-worker start --repo <url> --branch <branch> --purpose <purpose> [选项]
   claude-code-worker list
-  claude-code-worker stop <worker-id> [--force]
-  claude-code-worker logs <worker-id> [-f]
-  claude-code-worker status <worker-id>
+  claude-code-worker stop <id> [--force]
+  claude-code-worker logs <id> [-f]
+  claude-code-worker status <id>
   claude-code-worker build [--force]
 
-兼容简写（第一个参数为 --xxx 时自动视为 start）:
+# 兼容简写（与 start 等价）:
   claude-code-worker --repo <url> --branch <branch> --purpose <purpose>
 
 start 选项:
-  --repo           Git 仓库 URL（SSH 或 HTTPS）
-  --branch         要检出的分支
-  --purpose        任务描述（用于命名结果分支，如 bug-fixing, feature-login）
-  --ttyd-password  ttyd Basic Auth 密码（格式: password 或 user:password）
+  --ttyd-password  ttyd Basic Auth（格式: password 或 user:password）
   --backup-dir     push 失败时的本地备份目录
-  --no-ssh         不挂载宿主机 ~/.ssh
+  --no-ssh         不挂载 ~/.ssh
   --memory         容器内存限制（默认 4g）
-  --cpus           容器 CPU 限制（默认 2.0）
+  --cpus           CPU 限制（默认 2.0）
 ```
 
 ---
@@ -290,65 +303,71 @@ start 选项:
 ```bash
 ANTHROPIC_API_KEY=sk-ant-api03-xxxx
 
-# HTTPS push 时需要（与 SSH 二选一）
+# HTTPS push 时使用（与 SSH 二选一）
 # GIT_TOKEN=ghp_xxxx
 ```
 
 ---
 
-## 10. 完整使用流程
+## 10. 端口规划
+
+| 端口范围 | 绑定地址 | 用途 |
+|---|---|---|
+| 7700–7799 | 127.0.0.1 | worker ttyd（自动分配，最多 100 个并行） |
+
+---
+
+## 11. 安全模型
+
+| 风险 | 缓解措施 |
+|---|---|
+| API Key 泄露 | `--env-file`（不出现在命令行），`secrets.env` chmod 600 |
+| 容器逃逸 | 不挂载 Docker socket，无特权模式 |
+| 端口暴露 | 全部绑定 `127.0.0.1`，非 `0.0.0.0` |
+| 代码丢失 | push 失败时自动 tar 备份到 /output |
+| 资源失控 | `--memory 4g --cpus 2.0` 默认限制 |
+
+---
+
+## 12. 完整使用流程
 
 ```bash
-# 首次安装
+# 安装
 cd .claude-worker && chmod +x install.sh && ./install.sh
-vim ~/.claude-worker/secrets.env    # 填入 ANTHROPIC_API_KEY
+vim ~/.claude-worker/secrets.env   # 填入 ANTHROPIC_API_KEY
 
-# 启动 worker（按题目示例格式）
-claude-code-worker --repo git@github.com:myorg/myrepo.git \
+# 启动
+claude-code-worker --repo git@github.com:org/repo.git \
                    --branch release/4.0.0 \
                    --purpose bug-fixing
-# → 输出: 🚀 Worker 就绪! 打开 http://localhost:7700
+# → 🚀 就绪! http://localhost:7700
 
-# 并行启动第二个
-claude-code-worker --repo git@github.com:myorg/myrepo.git \
+# 并行第二个
+claude-code-worker --repo git@github.com:org/repo.git \
                    --branch main \
                    --purpose feature-login
-# → 输出: 🚀 Worker 就绪! 打开 http://localhost:7701
+# → 🚀 就绪! http://localhost:7701
 
-# 查看所有 worker
 claude-code-worker list
-
-# 完成后停止（会自动触发 push）
 claude-code-worker stop ccw-bug-fixing-20240403120000
 ```
 
 ---
 
-## 11. 端口规划
+## 13. 待确认事项（需在用户本地机器实测）
 
-| 端口范围 | 用途 |
-|---|---|
-| 7700–7799 | worker ttyd 端口（自动分配，只绑定 127.0.0.1） |
-
-最多支持 100 个并行 worker。所有端口仅绑定 localhost，不对外网暴露。
-
----
-
-## 12. 安全模型
-
-| 风险 | 缓解措施 |
-|---|---|
-| API Key 泄露 | `--env-file`（不出现在 CLI 历史），`secrets.env` chmod 600 |
-| 容器逃逸 | 不挂载 Docker socket，不给特权模式 |
-| 端口暴露 | 所有端口绑定 `127.0.0.1`，非 `0.0.0.0` |
-| 代码意外丢失 | push 失败时自动 tar 备份到 /output |
-| 容器资源失控 | `--memory 4g --cpus 2.0` 默认限制 |
+- [ ] `claude --dangerously-skip-permissions` 在容器内首次运行时是否会提示 OAuth？（若会，需先在 Dockerfile 内 pre-auth）
+- [ ] `ttyd --once` 连接断开后是否立即触发进程退出？（影响自动 push 时机）
+- [ ] native installer 在 Ubuntu 24.04 Docker 容器内安装路径：`/root/.local/bin/claude` 还是 `/opt/claude-code/bin/claude`？
+- [ ] 网络代理环境变量（`HTTP_PROXY` 等）是否需要透传进容器？
 
 ---
 
-## 13. 待确认事项
+## 14. 备注：当前 Firecracker 环境替代方案
 
-- [ ] `claude --bare` 参数是否在 2.1.91 版本可用（需实测）
-- [ ] ttyd `--once` 行为确认：连接断开后是否触发进程退出（影响自动 push）
-- [ ] 宿主机 Docker socket 权限（当前用户是否在 docker 组）
-- [ ] 网络代理配置是否需要透传进容器（`HTTP_PROXY` 等）
+当前 Claude Code Web 环境无 Docker daemon，若需在此环境测试并行，可用：
+- **tmux** (`/usr/bin/tmux 3.4`，已安装）创建多个 tmux session
+- **ttyd**（`apt install ttyd`）对外暴露各 session
+- 每个 tmux session 对应一个 git worktree
+
+但这种方式隔离性弱（共享同一文件系统和进程空间），仅适合轻量测试。

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,7 +1,7 @@
 # Claude Code Worker — 设计规格（Design Spec）
 
-**版本**: 0.3  
-**当前实现方案**: 方案 B — Vagrant + libvirt + Ubuntu Cloud Image  
+**版本**: 0.4  
+**当前实现方案**: 方案 A — Vagrant + libvirt + Ubuntu Cloud Image  
 **目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
 
 ---
@@ -332,7 +332,8 @@ fi
   claude-code-worker stop <id> [--force]
   claude-code-worker logs <id>
   claude-code-worker status <id>
-  claude-code-worker build-box [--force]   ← 构建 golden box（首次必须）
+  claude-code-worker review --branch <result-branch>   ← AI 审核（起新 worker 对结果分支做 review）
+  claude-code-worker build-box [--force]               ← 构建 golden box（首次必须）
 
 # 兼容简写:
   claude-code-worker --repo <url> --branch <branch> --purpose <purpose>
@@ -415,6 +416,38 @@ claude-code-worker stop ccw-bug-fixing-20240403120000
       → provision.sh 用 `find` 自动定位并建 symlink，已处理
 - [ ] SSH rsync 到 VM 时权限是否正确？
       → 已在 Vagrantfile 中指定 `--chmod=D700,F600`，实测确认
+
+### 2.16 待设计事项（需用户决策后补充）
+
+#### Worker 产物（VM 销毁前保存）
+worker push 前需生成并提交以下产物，具体内容待定：
+- 代码变更（已有）
+- spec/plan 文档
+- 初步 AI 自我 review 文档
+- 行为测试文档
+- 测试运行结果
+
+**待定问题**：
+- [ ] 产物存放位置：repo 内 `.worker-output/` 目录 vs PR description/comments？
+- [ ] 测试命令如何获取：从 Makefile/package.json 自动推断 vs 启动时 `--test-cmd` 指定？
+
+#### 审核流程
+- 支持人工和 AI 审核，按事项决定
+- `claude-code-worker review --branch result/xxx` 起新 worker 做 AI review
+- VM push 完立即销毁，VM 和 PR 生命周期解耦
+
+**待定问题**：
+- [ ] review worker 的产物如何回写：PR comment vs 新 commit vs 单独文件？
+- [ ] AI review 是否自动触发（push 后立即起 review worker）还是手动调用？
+- [ ] PR 是 worker 自动创建还是人工创建？
+
+#### API Key 获取方式（三选一，优先级顺序）
+1. 请求 URL（动态，不落磁盘）—— `SECRET_URL` + `SECRET_TOKEN`
+2. 挂载目录文件读取 —— `/secrets/anthropic_api_key`
+3. 环境变量兜底 —— `ANTHROPIC_API_KEY`
+
+**待定问题**：
+- [ ] 用户的 secret server 方案（自建 vs Vault vs 云服务）？
 
 ---
 

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -449,6 +449,20 @@ worker push 前需生成并提交以下产物，具体内容待定：
 **待定问题**：
 - [ ] 用户的 secret server 方案（自建 vs Vault vs 云服务）？
 
+#### install.sh（一次性环境准备）
+用途：让本地机器具备运行 `claude-code-worker` 的条件（类比"装 Docker Engine"）。
+执行顺序：`install.sh` → `build-box` → 日常 `start`。
+
+需要完成：
+1. 检查 KVM 可用性（`kvm-ok`）、libvirt daemon 状态、用户是否在 `libvirt` 组
+2. 安装 `vagrant-libvirt` plugin 及其系统依赖（`libvirt-dev`、`ruby-dev`）
+3. 下载 base box（`vagrant box add generic/ubuntu2404`，几百 MB）
+4. 初始化 `~/.claude-worker/` 目录结构和 `secrets.env` 模板
+5. 将 `claude-code-worker` symlink 到 `/usr/local/bin/`
+
+**待定问题**：
+- [ ] 是否需要 install.sh，还是用户手动处理依赖即可？
+
 ---
 
 ## 3. 方案 B（演进）：Weaveworks Ignite — Firecracker 封装

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,6 +1,6 @@
 # Claude Code Worker — 设计规格（Design Spec）
 
-**版本**: 0.4  
+**版本**: 0.5  
 **当前实现方案**: 方案 A — Vagrant + libvirt + Ubuntu Cloud Image  
 **目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
 
@@ -154,6 +154,11 @@ end
 
 ### 2.6 build-box/provision.sh
 
+> ⚠️ 路径说明：Vagrant 的 synced_folder 默认只挂载 `build-box/` 目录为 `/vagrant`，
+> 无法直接访问 `vm/` 下的脚本。解法：`build-box/Vagrantfile` 额外 sync `vm/` 目录，
+> 或在 provision.sh 里用 curl/wget 从本地 HTTP 服务获取，或在打包前手动复制。
+> 最简方案：在 `build-box/Vagrantfile` 中添加 `config.vm.synced_folder "../vm", "/vm-scripts"`。
+
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
@@ -180,9 +185,9 @@ ln -sf "$CLAUDE_BIN" /usr/local/bin/claude
 # 验证安装
 claude --version
 
-# 写入 entrypoint 和 push 脚本
-cp /vagrant/../vm/entrypoint.sh /usr/local/bin/entrypoint.sh
-cp /vagrant/../vm/push-and-exit.sh /usr/local/bin/push-and-exit.sh
+# 写入 entrypoint 和 push 脚本（由 build-box/Vagrantfile sync /vm-scripts 挂载）
+cp /vm-scripts/entrypoint.sh /usr/local/bin/entrypoint.sh
+cp /vm-scripts/push-and-exit.sh /usr/local/bin/push-and-exit.sh
 chmod +x /usr/local/bin/entrypoint.sh /usr/local/bin/push-and-exit.sh
 
 echo "[provision] Golden box 构建完成"
@@ -230,6 +235,14 @@ end
 
 ### 2.8 vm/entrypoint.sh
 
+API Key 三层获取逻辑（优先级：URL > 挂载文件 > 环境变量）：
+- URL 方式：key 只进内存，不落磁盘，最安全
+- 文件挂载：key 通过 rsync 进 VM，存在磁盘，需权限保护
+- 环境变量：兜底，通过 Vagrant `env:` 注入
+
+> ⚠️ 注意：`/etc/environment` 会落磁盘，仅在无更好方案时作为兜底使用。
+> VM 销毁后磁盘随之销毁，风险可控；但在 VM 存活期间 key 可被读取。
+
 ```bash
 #!/usr/bin/env bash
 set -euo pipefail
@@ -238,12 +251,25 @@ set -euo pipefail
 : "${WORKER_BRANCH:?需要 WORKER_BRANCH}"
 : "${WORKER_PURPOSE:?需要 WORKER_PURPOSE}"
 : "${WORKER_ID:?需要 WORKER_ID}"
-: "${ANTHROPIC_API_KEY:?需要 ANTHROPIC_API_KEY}"
+
+# ── API Key 三层获取（优先级：URL > 挂载文件 > 环境变量）──────
+if [[ -n "${SECRET_URL:-}" ]]; then
+    # 层 1：从 URL 动态获取，key 只进内存
+    ANTHROPIC_API_KEY=$(curl -sf "$SECRET_URL" \
+        -H "Authorization: Bearer ${SECRET_TOKEN:-}" \
+        | grep -o '"api_key":"[^"]*"' | cut -d'"' -f4)
+elif [[ -f "/secrets/anthropic_api_key" ]]; then
+    # 层 2：从挂载文件读取
+    ANTHROPIC_API_KEY=$(cat /secrets/anthropic_api_key)
+else
+    # 层 3：从环境变量（Vagrant env: 注入）
+    : "${ANTHROPIC_API_KEY:?未配置 API Key（需 SECRET_URL、/secrets/anthropic_api_key 或 ANTHROPIC_API_KEY 之一）}"
+fi
+export ANTHROPIC_API_KEY
 
 # 写入全局环境（使 ttyd 启动的子进程也能读取）
-cat >> /etc/environment << EOF
-ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-EOF
+# 仅在环境变量兜底路径下 key 会落磁盘；URL/文件路径 key 只在此进程内存中
+echo "ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}" >> /etc/environment
 
 RESULT_BRANCH="result/${WORKER_PURPOSE}-$(date +%Y%m%d-%H%M%S)"
 TTYD_PORT="${TTYD_PORT:-7681}"
@@ -332,8 +358,8 @@ fi
   claude-code-worker stop <id> [--force]
   claude-code-worker logs <id>
   claude-code-worker status <id>
-  claude-code-worker review --branch <result-branch>   ← AI 审核（起新 worker 对结果分支做 review）
-  claude-code-worker build-box [--force]               ← 构建 golden box（首次必须）
+  claude-code-worker review --repo <url> --branch <result-branch> [--purpose review]
+  claude-code-worker build-box [--force]
 
 # 兼容简写:
   claude-code-worker --repo <url> --branch <branch> --purpose <purpose>
@@ -343,6 +369,13 @@ start 选项:
   --memory         VM 内存（默认 2048，单位 MB）
   --cpus           VM CPU 数（默认 2）
   --no-ssh         不同步 ~/.ssh 进 VM
+  --secret-url     API Key 获取 URL（层 1）
+  --secret-token   SECRET_URL 的 Bearer Token
+
+review 说明:
+  起一个新 worker VM，检出 <result-branch>，claude 阅读变更并生成 review。
+  review 结果存放位置待定（见 2.16 待设计事项）。
+  worker 完成后自动销毁。
 ```
 
 ### 2.11 配置文件
@@ -353,7 +386,8 @@ ANTHROPIC_API_KEY=sk-ant-api03-xxxx
 # GIT_TOKEN=ghp_xxxx   # HTTPS push 时使用
 ```
 
-CLI 启动时自动 `source` 此文件，通过 Vagrantfile `env:` 注入 VM。
+CLI 启动时读取此文件并导出为进程环境变量，通过 Vagrantfile `env:` 注入 VM。
+Ruby 读取的是进程环境（`ENV["KEY"]`），需要 CLI 在调用 `vagrant` 前先 `export`。
 
 ### 2.12 端口规划
 

--- a/.claude-worker/SPEC.md
+++ b/.claude-worker/SPEC.md
@@ -1,6 +1,6 @@
 # Claude Code Worker — 设计规格（Design Spec）
 
-**版本**: 0.5  
+**版本**: 0.6  
 **当前实现方案**: 方案 A — Vagrant + libvirt + Ubuntu Cloud Image  
 **目标**: 让用户通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。
 
@@ -575,3 +575,123 @@ sudo apt install kata-containers
 | **Docker Registry** | 不需要 | 不需要 | 可选 |
 | **团队共享** | 困难（.box 文件大） | 中等 | 容易（Registry） |
 | **迁移成本** | — | 低（替换 ~50 行） | 低（替换 ~50 行） |
+
+---
+
+## 6. 会话持久化技术路径（待确认）
+
+> 📋 本节记录对 Anthropic Claude Code Web 会话持久化机制的技术分析，
+> 作为后续为 claude-code-worker 实现会话持久化的参考路径。
+> 结论来自对当前运行环境的实测推断，未经 Anthropic 官方确认。
+
+### 6.1 已知线索（实测）
+
+```
+PID 1:      /process_api --firecracker-init  （VM 内部，替代 systemd）
+Git remote: http://local_proxy@127.0.0.1:43563/git/ekeyme/python-appimage-ots
+~/.claude/
+├── sessions/    ← 本地会话元数据（session ID 等）
+├── projects/    ← 项目数据
+└── settings.json
+```
+
+### 6.2 整体架构
+
+```
+宿主机（Anthropic 物理服务器）
+│
+├── Firecracker VMM 进程（宿主机上）
+│   - 分配内存、CPU
+│   - 加载 VM 内核镜像 + rootfs 镜像
+│   - 配置 virtio 网络/磁盘设备
+│   └── ↓ 内核启动后控制权交给 VM 内部
+│
+└── Firecracker VM 内部
+    ├── Linux 内核（6.18.5）
+    └── PID 1: /process_api --firecracker-init
+            ├── 从对象存储拉取 ~/.claude/ 到 VM 磁盘
+            ├── 挂载 git 工作目录（通过本地 git proxy）
+            ├── 启动 git proxy（127.0.0.1:43563）
+            └── 启动 claude 进程
+```
+
+### 6.3 会话数据的分层存储
+
+```
+┌─────────────────────────────────────────────┐
+│             Anthropic 数据中心               │
+│                                             │
+│  ┌──────────────────┐  ┌─────────────────┐  │
+│  │    对话数据库     │  │   用户文件存储   │  │
+│  │  (PostgreSQL /   │  │   (S3-like      │  │
+│  │   DynamoDB 等)   │  │    对象存储)     │  │
+│  │                  │  │                 │  │
+│  │  session_id  →   │  │  user_id →      │  │
+│  │  messages[]      │  │  ~/.claude/     │  │
+│  └──────────────────┘  └─────────────────┘  │
+└─────────────────────────────────────────────┘
+          ↑ 实时写入（每条消息）    ↑ sync
+          │                        │
+┌─────────────────────────────────────────────┐
+│             Firecracker VM                  │
+│                                             │
+│  process_api 启动时：                        │
+│  → 从对象存储 sync ~/.claude/ 到 VM 磁盘     │
+│                                             │
+│  claude 进程运行中：                          │
+│  → 每条消息实时写入对话数据库（流式）           │
+│  → ~/.claude/ 变更定期 sync 回对象存储        │
+│                                             │
+│  VM 销毁时：                                 │
+│  → ~/.claude/ 最终 sync 回对象存储           │
+└─────────────────────────────────────────────┘
+```
+
+### 6.4 文件持久化机制推断
+
+**工作目录（代码文件）**：通过 git 持久化
+```
+VM 内 /home/user/<project>/
+    ↕  git push / git pull
+GitHub 仓库（通过 127.0.0.1:43563 代理）
+```
+未 push 的本地改动在 VM 销毁后丢失。
+
+**`~/.claude/` 目录**：通过对象存储持久化
+```
+VM 启动  → 对象存储 sync 到 VM 磁盘
+运行中   → 定期/增量 sync 回对象存储
+VM 销毁  → 最终 sync 确保不丢数据
+```
+
+**对话消息内容**：实时写入数据库，与 VM 生命周期完全解耦
+```
+用户发消息 → 立即写入 Anthropic 数据库
+AI 回复    → token 边生成边写入
+VM 崩溃    → 已发送的消息不丢失
+```
+
+### 6.5 process_api 的角色
+
+`process_api` 是 Anthropic 自定义的 PID 1（替代 systemd），bake 进 rootfs 镜像。
+
+| 传统 VM | Anthropic Firecracker VM |
+|---|---|
+| PID 1: systemd | PID 1: /process_api |
+| 启动所有系统服务 | 只做用户数据挂载 + claude 启动 |
+| 启动慢（秒级） | 极轻量，配合 Firecracker 实现 125ms 启动 |
+| 通用 | 完全为 Claude Code Web 定制 |
+
+### 6.6 对 claude-code-worker 的参考意义
+
+我们的 `entrypoint.sh` 已经是简化版的 `process_api`，可以参考 Anthropic 的做法进一步演进：
+
+| Anthropic 做法 | claude-code-worker 当前 | 可演进方向 |
+|---|---|---|
+| 对象存储 sync ~/.claude/ | ❌ 未实现 | MinIO 或 NFS 挂载 ~/.claude/ |
+| 对话数据库实时写入 | ❌ 未实现 | SQLite 本地存储 + 定期备份 |
+| git proxy（本地代理） | 直接 git clone | 可选：本地 git mirror 加速 |
+| 工作目录持久化 | git push 到 result 分支 | ✅ 已覆盖 |
+| VM 销毁前 sync | push-and-exit.sh | ✅ 已覆盖（代码层面） |
+
+**优先级建议**：对于个人开发工具，`~/.claude/` 持久化（保留 claude 本地配置和会话元数据）收益最大，可用 rsync 到宿主机目录实现，成本极低。


### PR DESCRIPTION
## 概述

本 PR 包含 Claude Code Worker 并行环境系统的完整设计文档，以及探索 Claude Code Web 运行环境的过程记录。

## 文件

### `.claude-worker/SPEC.md` — 设计规格文档（v0.6）

系统目标：通过一条命令启动多个隔离的 Claude Code 工作环境，每个环境对应一个 git 分支，在浏览器中与 Claude Code 交互完成任务，结果自动推送到结果分支。

**核心方案（方案 A）：Vagrant + libvirt + Ubuntu Cloud Image**
- KVM 虚拟机隔离，每个 worker 独立内核
- Golden box 策略：一次性构建预装环境，启动时间 5–15 秒
- ttyd 将 Claude Code TUI 包装为浏览器终端（WebSocket）
- API Key 三层获取：URL 动态获取 > 挂载文件 > 环境变量
- push 完立即销毁 VM，支持人工 + AI 审核

**演进路线**：
- 方案 B：Weaveworks Ignite（Firecracker 封装，~1 秒启动）
- 方案 C：Kata Containers（Docker CLI + VM 隔离，1–2 秒启动）
- 三方案共用 entrypoint.sh / push-and-exit.sh / CLI 接口，迁移成本低

**第 6 节（新增）：会话持久化技术路径**
- 对 Anthropic Claude Code Web 会话持久化机制的深度分析（基于实测推断）
- 三层存储模型：对话数据库（实时写入）+ 对象存储（~/.claude/）+ git（代码）
- process_api 作为自定义 PID 1 替代 systemd 的原理及启动流程图
- claude-code-worker 可参考的演进方向（~/.claude/ 持久化优先级最高）

### `.claude-worker/EXPLORATION.md` — 探索过程文档

记录"用 Claude Code 探究 Claude Code Web 环境"的完整过程：
- 发现当前环境是 Anthropic 专有 Firecracker VM（非 Docker）
- Claude Code 是 230MB 静态编译 ELF 二进制，无内置 web server 模式
- 完整开发工具链基线（Python/Node/Go/Rust/Java/Ruby/PHP 版本）
- 从 Docker 方案演变为 Vagrant+libvirt 方案的决策过程

## 待定事项（后续 PR 补充）

- [ ] Worker 产物存放位置（`.worker-output/` vs PR comments）
- [ ] 测试命令获取方式（自动推断 vs `--test-cmd` 指定）
- [ ] review worker 产物回写方式
- [ ] API Key 获取的 secret server 选型
- [ ] install.sh 是否需要实现
- [ ] ~/.claude/ 持久化方案（rsync to host / MinIO）

## 备注

本 PR 为纯设计文档，不含可运行代码，作为后续实现的参考规格。

https://claude.ai/code/session_01M5V6inRVjiZw4NHjroG54o